### PR TITLE
Bump tree-sitter base version and fix Clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,18 +9,13 @@ edition = "2018"
 license = "MIT"
 
 build = "bindings/rust/build.rs"
-include = [
-  "bindings/rust/*",
-  "grammar.js",
-  "queries/*",
-  "src/*",
-]
+include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
 
 [lib]
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.20"
+tree-sitter = "0.22"
 
 [build-dependencies]
 cc = "1.0"

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -2,7 +2,7 @@ fn main() {
     let src_dir = std::path::Path::new("src");
 
     let mut c_config = cc::Build::new();
-    c_config.include(&src_dir);
+    c_config.include(src_dir);
     c_config
         .flag_if_supported("-Wno-unused-parameter")
         .flag_if_supported("-Wno-unused-but-set-variable")

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -6,7 +6,7 @@
 //! ```
 //! let code = "";
 //! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(tree_sitter_gowork::language()).expect("Error loading gowork grammar");
+//! parser.set_language(&tree_sitter_gowork::language()).expect("Error loading gowork grammar");
 //! let tree = parser.parse(code, None).unwrap();
 //! ```
 //!
@@ -31,7 +31,7 @@ pub fn language() -> Language {
 /// The content of the [`node-types.json`][] file for this grammar.
 ///
 /// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
-pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
+pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
 // Uncomment these to include any queries that this grammar contains
 
@@ -46,7 +46,7 @@ mod tests {
     fn test_can_load_grammar() {
         let mut parser = tree_sitter::Parser::new();
         parser
-            .set_language(super::language())
+            .set_language(&super::language())
             .expect("Error loading gowork language");
     }
 }


### PR DESCRIPTION
When bumping to a newer tree-sitter-markdown library, I've realized that all dependencies have to depend on the same `tree-sitter` in https://github.com/zed-industries/zed/blob/b0187ab3e746709eed7a50a8fd7469fd8ba145f1/crates/languages/src/lib.rs#L38-L59 and other ways to override it are not very reliable.

Ergo the PR to bump the library version + some small Clippy fixes along the way.